### PR TITLE
Update fan control tutorial and Home Assistant driver docs

### DIFF
--- a/docs/source/agent-framework/driver-framework/home-assistant/HomeAssistantDriver.rst
+++ b/docs/source/agent-framework/driver-framework/home-assistant/HomeAssistantDriver.rst
@@ -1,11 +1,14 @@
 .. _HomeAssistant-Driver:
-This is Luwei Yang's Lab 6 modification- Testing Sphinx Build.
+
 Home Assistant Driver
 =====================
 
 The Home Assistant driver enables VOLTTRON to read any data point from any Home Assistant controlled device.
-Currently control(write access) is supported only for lights(state and brightness) and thermostats(state and temperature).
+Write (control) access is supported for the following domains: light(state and brightness), climate(state and temperature), fan(state and percentage), and input_boolean(state).
 
+For a step-by-step customer workflow and validation flow, see
+:ref:`Home Assistant Fan Control with VOLTTRON <HomeAssistant-Write-Tutorial>`.
+ 
 The following diagram shows interaction between platform driver agent and home assistant driver.
 
 .. mermaid::
@@ -36,12 +39,12 @@ After cloning, generate configuration files. Each device requires one device con
 Ensure your registry_config parameter in your device configuration file, links to correct registry config name in the
 config store. For more details on how volttron platform driver agent works with volttron configuration store see,
 `Platform driver configuration <https://volttron.readthedocs.io/en/main/agent-framework/driver-framework/platform-driver/platform-driver.html#configuration-and-installation>`_
-Examples for lights and thermostats are provided below.
+Examples for lights, thermostats, fans, and input booleans are provided below.
 
 Device configuration
 ++++++++++++++++++++
 
-Device configuration file contains the connection details to you home assistant instance and driver_type as "home_assistant"
+Device configuration file contains the connection details to your Home Assistant instance and driver_type as "home_assistant".
 
 .. code-block:: json
 
@@ -61,10 +64,11 @@ Registry Configuration
 +++++++++++++++++++++++
 
 Registry file can contain one single device and its attributes or a logical group of devices and its
-attributes. Each entry should include the full entity id of the device, including but not limited to home assistant provided prefix
-such as "light.",  "climate." etc. The driver uses these prefixes to convert states into integers.
-Like mentioned before, the driver can only control lights and thermostats but can get data from all devices
-controlled by home assistant
+attributes. Each entry should include the full entity id of the device, including but not limited to Home Assistant provided prefixes
+such as "light.", "climate.", "fan.", and "input_boolean.". The driver uses these prefixes to convert states into integers and route writes.
+Write/control is supported for ``light`` (state, brightness), ``climate`` (state, temperature), ``fan`` (state, percentage), and
+``input_boolean`` (state). You can still read points from many Home Assistant entities, but write behavior is implemented for the
+supported domains and points listed above.
 
 Each entry in a registry file should also have a 'Entity Point' and a unique value for 'Volttron Point Name'. The 'Entity ID' maps to the device instance, the 'Entity Point' extracts the attribute or state, and 'Volttron Point Name' determines the name of that point as it appears in VOLTTRON.
 
@@ -87,8 +91,8 @@ id 'light.example':
            "Units": "On / Off",
            "Units Details": "on/off",
            "Writable": true,
-           "Starting Value": true,
-           "Type": "boolean",
+           "Starting Value": 0,
+           "Type": "int",
            "Notes": "lights hallway"
        },
        {
@@ -140,7 +144,7 @@ For thermostats, the state is converted into numbers as follows: "0: Off, 2: hea
            "Volttron Point Name": "volttron_current_temperature",
            "Units": "F",
            "Units Details": "Current Ambient Temperature",
-           "Writable": true,
+           "Writable": false,
            "Starting Value": 72,
            "Type": "float",
            "Notes": "Current temperature reading"
@@ -158,16 +162,90 @@ For thermostats, the state is converted into numbers as follows: "0: Off, 2: hea
        }
    ]
 
+Example Fan Registry
+********************
+ 
+For fans, the state is represented as 0 (off) or 1 (on), and percentage controls the fan speed from 0 to 100.
+ 
+.. code-block:: json
+ 
+   [
+       {
+           "Entity ID": "fan.example",
+           "Entity Point": "state",
+           "Volttron Point Name": "fan_state",
+           "Units": "On / Off",
+           "Units Details": "0: off, 1: on",
+           "Writable": true,
+           "Starting Value": 0,
+           "Type": "int",
+           "Notes": "Fan on/off state"
+       },
+       {
+           "Entity ID": "fan.example",
+           "Entity Point": "percentage",
+           "Volttron Point Name": "fan_percentage",
+           "Units": "Percent",
+           "Units Details": "Fan speed percentage, 0 - 100",
+           "Writable": true,
+           "Starting Value": 0,
+           "Type": "int",
+           "Notes": "Fan speed percentage control, 0 - 100"
+       }
+   ]
 
 
-Transfer the registers files and the config files into the VOLTTRON config store using the commands below:
+Example Input Boolean Registry
+*******************************
+
+For input_boolean helpers, the state is represented as 0 (off) or 1 (on) when read through the driver.
+For writes, ``set_point`` accepts ``0`` or ``1``; the driver maps that to a Home Assistant ``input_boolean`` service
+call. The exact REST service name depends on the driver version—see
+``InputBooleanHandler`` in ``services/core/PlatformDriverAgent/.../handlers/`` in your checkout.
+ 
+.. code-block:: json
+ 
+   [
+       {
+           "Entity ID": "input_boolean.example",
+           "Entity Point": "state",
+           "Volttron Point Name": "input_boolean_state",
+           "Units": "On / Off",
+           "Units Details": "0: off, 1: on",
+           "Writable": true,
+           "Starting Value": 0,
+           "Type": "int",
+           "Notes": "Input boolean state"
+       }
+   ]
+
+
+Before starting the platform driver, store the registry files and config files 
+for each device into the VOLTTRON config store.
+
+Each device requires two files:
+
+- **Registry file** (``.json``) – defines the data points of the device (e.g., brightness, state).
+- **Config file** (``.config``) – defines how the driver connects to the device.
+
+Run the following commands to store the files for each device:
 
 .. code-block:: bash
 
    vctl config store platform.driver light.example.json HomeAssistant_Driver/light.example.json
    vctl config store platform.driver devices/BUILDING/ROOM/light.example HomeAssistant_Driver/light.example.config
 
-Upon completion, initiate the platform driver. Utilize the listener agent to verify the driver output:
+   vctl config store platform.driver thermostat.example.json HomeAssistant_Driver/thermostat.example.json
+   vctl config store platform.driver devices/BUILDING/ROOM/thermostat.example HomeAssistant_Driver/thermostat.example.config
+
+   vctl config store platform.driver fan.example.json HomeAssistant_Driver/fan.example.json
+   vctl config store platform.driver devices/BUILDING/ROOM/fan.example HomeAssistant_Driver/fan.example.config
+
+   vctl config store platform.driver input_boolean.example.json HomeAssistant_Driver/input_boolean.example.json
+   vctl config store platform.driver devices/BUILDING/ROOM/input_boolean.example HomeAssistant_Driver/input_boolean.example.config
+
+Once completed, start the platform driver and use the listener agent to verify 
+the output. A successful result looks like the following:
 
 .. code-block:: bash
 
@@ -176,11 +254,9 @@ Upon completion, initiate the platform driver. Utilize the listener agent to ver
     {'light_brightness': {'type': 'integer', 'tz': 'UTC', 'units': 'int'},
      'state': {'type': 'integer', 'tz': 'UTC', 'units': 'On / Off'}}]
 
-Running Tests
-+++++++++++++++++++++++
-To run tests on the VOLTTRON home assistant driver you need to create a helper in your home assistant instance. This can be done by going to **Settings > Devices & services > Helpers > Create Helper > Toggle**. Name this new toggle **volttrontest**. After that run the pytest from the root of your VOLTTRON file.
+Automated tests
++++++++++++++++
 
-.. code-block:: bash
-    pytest volttron/services/core/PlatformDriverAgent/tests/test_home_assistant.py
-
-If everything works, you will see 6 passed tests.
+Automated tests for this driver live under ``services/core/PlatformDriverAgent/tests/`` in the VOLTTRON source tree.
+Contributors and integrators who run the test suite should follow the repository’s development and testing
+documentation; day-to-day use of the driver does not require running those tests.

--- a/docs/source/tutorials/home-assistant-write-tutorial.rst
+++ b/docs/source/tutorials/home-assistant-write-tutorial.rst
@@ -1,0 +1,302 @@
+.. _HomeAssistant-Write-Tutorial:
+
+========================================
+Home Assistant Fan Control with VOLTTRON
+========================================
+
+This guide helps customer teams control fan state and speed through VOLTTRON and verify that commands are applied correctly in Home Assistant.
+
+**Home Assistant Website**: https://www.home-assistant.io
+
+For full driver capabilities, supported writable points, and registry examples across domains,
+see :ref:`Home Assistant Driver <HomeAssistant-Driver>`.
+
+**What you will achieve:**
+
+- Turn a fan on and off from VOLTTRON
+- Set fan speed percentage
+- Confirm expected behavior in the Home Assistant UI and logs
+
+---
+
+Architecture Overview
+======================
+
+The full control chain is:
+
+.. mermaid::
+
+   flowchart TD
+      A[Agent or CLI<br/>RPC set_point / get_point] --> B[platform.driver]
+      B --> C[home_assistant interface<br/>home_assistant.py]
+      C --> D[handlers/<br/>FanHandler, LightHandler,<br/>ClimateHandler, InputBooleanHandler]
+      D --> E[HA REST API<br/>http://&lt;HA_IP&gt;:8123/api/services/...]
+      E --> F[Home Assistant entity]
+
+- **platform.driver**: VOLTTRON's device driver framework
+- **home_assistant.py**: The HA-specific driver interface
+- **handlers/**: Per-domain handler classes (``FanHandler``, ``LightHandler``, ``ClimateHandler``, ``InputBooleanHandler``)
+- **HA REST API**: Home Assistant's HTTP API (port 8123)
+
+---
+
+Chapter 1: Home Assistant Prerequisites
+=========================================
+
+1.1 Create Helper Entities
+---------------------------
+
+In the HA web UI: **Settings → Devices & Services → Helpers → Create Helper**
+
+- **Toggle** — Name: ``fan_state`` → creates ``input_boolean.fan_state``
+- **Number** — Name: ``fan_speed``, Min: 0, Max: 100 → creates ``input_number.fan_speed``
+
+1.2 Add Template Fan to configuration.yaml
+-------------------------------------------
+
+.. code-block:: bash
+
+    $ docker exec -it homeassistant bash
+    $ vi /config/configuration.yaml
+
+Add the following at the end of the file:
+
+.. code-block:: yaml
+
+    fan:
+      - platform: template
+        fans:
+          volttron_test_fan:
+            friendly_name: "Volttron Test Fan"
+            value_template: "{{ states('input_boolean.fan_state') }}"
+            percentage_template: "{{ states('input_number.fan_speed') }}"
+            turn_on:
+              service: input_boolean.turn_on
+              target:
+                entity_id: input_boolean.fan_state
+            turn_off:
+              service: input_boolean.turn_off
+              target:
+                entity_id: input_boolean.fan_state
+            set_percentage:
+              service: input_number.set_value
+              target:
+                entity_id: input_number.fan_speed
+              data:
+                value: "{{ percentage }}"
+
+1.3 Restart Home Assistant
+---------------------------
+
+.. code-block:: bash
+
+    $ exit   # exit the container shell first
+    $ docker restart homeassistant
+
+Verify that ``fan.volttron_test_fan`` appears in the HA dashboard.
+
+1.4 Generate a Long-Lived Access Token
+----------------------------------------
+
+In the HA web UI: click your **username** (bottom left) → scroll to **Long-Lived Access Tokens** → **Create Token** → copy the token.
+
+.. warning::
+
+    Copy the token immediately — it will not be shown again.
+
+---
+
+Chapter 2: How to Validate It Works
+====================================
+
+Use one of the following validation paths based on your operational workflow.
+
+Recommended Validation Workflow
+-------------------------------
+
+Use this checklist to validate the integration from an operations perspective:
+
+- Run control actions from the **CLI** (the HA web UI is used to visually verify state changes).
+- Show one **existing** functionality still works (recommended: ``input_boolean`` state write/read).
+- Show the **new** functionality works (``fan`` state and ``fan`` percentage write/read).
+- Generate local docs (for example, ``make html`` under ``docs/``) and open the built HTML in a browser.
+- Briefly walk through this tutorial and the :ref:`Home Assistant Driver <HomeAssistant-Driver>` page
+  to show how teams can repeat the workflow.
+
+2.1 UI Validation (Primary)
+----------------------------
+
+For most deployments, use CLI actions with UI verification:
+
+- Trigger state updates from the CLI or an agent workflow.
+- Verify ``input_boolean`` state changes in the Home Assistant UI.
+- Verify ``fan.volttron_test_fan`` on/off and percentage changes in the Home Assistant UI.
+- Review logs to confirm the write path completes without errors.
+
+This path is sufficient for functional validation. The automated tests below are optional additional evidence.
+
+**Existing capability check (input_boolean):**
+
+1. Trigger an ``input_boolean`` state change from the CLI or your agent workflow.
+2. In the Home Assistant UI, confirm the corresponding ``input_boolean`` entity changes state.
+3. In logs, confirm the write path completed without blocking errors.
+
+Expected result: the ``input_boolean`` state reflects the requested command and remains readable through the driver.
+
+**Acceptance criteria:**
+
+- Existing toggle behavior (``input_boolean``) changes to the requested state.
+- Fan on/off state matches the requested command.
+- Fan percentage matches the requested value.
+- ``input_boolean`` state change is visible in the Home Assistant UI and confirmed in logs.
+- Relevant driver/log entries show successful execution and no blocking errors.
+
+2.2 Advanced: Automated Test Validation (Optional)
+---------------------------------------------------
+
+Use this section when your team needs automated regression evidence in addition to UI and log verification.
+
+Test Files
+-----------
+
+**test_ha_fan_live.py (Standalone — Recommended)**
+
+Location: ``services/core/PlatformDriverAgent/tests/test_ha_fan_live.py``
+
+Tests the fan write path end-to-end against a live HA instance **without requiring a running VOLTTRON platform**.
+It calls the HA REST API directly using ``requests``.
+
+- Each test is guarded by ``skip_if_no_env`` and will be skipped if the required environment variables are not set.
+- A ``reset_fan`` fixture with yield-based teardown runs after every test to restore the fan and speed helper to their initial state (off / 0), preventing test pollution.
+
+**Test coverage:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Test
+     - What it verifies
+   * - ``test_fan_get_point``
+     - Reading fan state returns ``"off"`` when fan is off
+   * - ``test_fan_set_point_on``
+     - Calling turn_on sets state to ``"on"``
+   * - ``test_fan_set_point_off``
+     - Calling turn_off sets state to ``"off"``
+   * - ``test_fan_set_point_percentage``
+     - Setting percentage to 60 reflects in ``input_number.fan_speed``
+   * - ``test_fan_scrape_all``
+     - Both ``fan.volttron_test_fan`` and ``input_number.fan_speed`` are readable
+
+**test_home_assistant.py (VOLTTRON Platform Integration)**
+
+Location: ``services/core/PlatformDriverAgent/tests/test_home_assistant.py``
+
+Runs through the full VOLTTRON platform driver stack, including ``_set_point → handler_registry →
+FanHandler.build_operation → _execute_service``. This suite requires a running VOLTTRON instance and uses the
+``volttron_instance`` fixture from ``volttrontesting``.
+
+Fan-specific additions include a ``fan_config_store`` fixture that registers ``fan.volttron_test_fan``
+with both ``state`` and ``percentage`` points, and a yield-based teardown that resets the fan helpers after each test.
+
+2.3 Step 1: Set Environment Variables
+---------------------------------------
+
+.. code-block:: bash
+
+    $ export HOMEASSISTANT_TEST_IP="localhost"
+    $ export ACCESS_TOKEN="your_long_lived_token_here"
+    $ export PORT="8123"
+
+2.4 Step 2: Activate the VOLTTRON Virtual Environment
+------------------------------------------------------
+
+.. code-block:: bash
+
+    $ source /path/to/volttron/env/bin/activate
+
+2.5 Step 3: Run the Standalone Live Tests
+------------------------------------------
+
+.. code-block:: bash
+
+    $ python -m pytest services/core/PlatformDriverAgent/tests/test_ha_fan_live.py -v
+
+Expected output::
+
+    test_ha_fan_live.py::test_fan_get_point PASSED
+    test_ha_fan_live.py::test_fan_set_point_on PASSED
+    test_ha_fan_live.py::test_fan_set_point_off PASSED
+    test_ha_fan_live.py::test_fan_set_point_percentage PASSED
+    test_ha_fan_live.py::test_fan_scrape_all PASSED
+
+    5 passed in 6.36s
+
+2.6 Step 4: Run the Unit Dispatch Tests (no HA required)
+---------------------------------------------------------
+
+.. code-block:: bash
+
+    $ python -m pytest \
+        services/core/PlatformDriverAgent/tests/test_home_assistant_handler_dispatch.py \
+        -v -m driver_unit
+
+These tests mock the HA API and validate that the handler registry correctly dispatches fan write
+operations without any network calls.
+
+2.7 Environment Constraints
+----------------------------
+
+.. note::
+
+    - Tests in ``test_home_assistant.py`` that depend on ``volttron_instance`` require a fully configured
+      VOLTTRON environment and will show ``ERROR`` if VOLTTRON is not running locally.
+    - Tests tagged with ``RabbitMQ is not setup`` are automatically skipped in environments without
+      RabbitMQ/SSL configured — this is expected behavior.
+    - The standalone ``test_ha_fan_live.py`` has no VOLTTRON dependency and is the recommended way
+      to validate the fan write path in a local development environment.
+    - All tests default to **skipped** unless the three environment variables
+      (``HOMEASSISTANT_TEST_IP``, ``ACCESS_TOKEN``, ``PORT``) are set in the same shell session before running pytest.
+---
+
+Reference Table
+===============
+
+All supported domains, entity points, writability, and value semantics:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 15 45
+
+   * - Domain
+     - Entity Point
+     - Writable
+     - Value Semantics
+   * - ``fan``
+     - ``state``
+     - Yes
+     - 0 = off, 1 = on
+   * - ``fan``
+     - ``percentage``
+     - Yes
+     - Fan speed, 0–100
+   * - ``light``
+     - ``state``
+     - Yes
+     - 0 = off, 1 = on
+   * - ``light``
+     - ``brightness``
+     - Yes
+     - Brightness level, 0–255
+   * - ``climate``
+     - ``state``
+     - Yes
+     - 0 = off, 2 = heat, 3 = cool, 4 = auto
+   * - ``climate``
+     - ``temperature``
+     - Yes
+     - Target temperature in °F (45–95)
+   * - ``input_boolean``
+     - ``state``
+     - Yes
+     - 0 = off, 1 = on (toggles each call)


### PR DESCRIPTION
**Summary**

- Add a new customer-oriented tutorial page: `docs/source/tutorials/home-assistant-write-tutorial.rst`.
- Reframe validation guidance around operational outcomes (CLI actions, UI verification, and log checks), including both existing `input_boolean` behavior and new fan state/percentage behavior.
- Update `docs/source/agent-framework/driver-framework/home-assistant/HomeAssistantDriver.rst` cross-reference text to match the tutorial naming.

**Why**

- Provide a clearer, end-to-end workflow that teams can follow to configure and validate Home Assistant fan control through VOLTTRON.
- Make it easier to demonstrate both backward compatibility (existing behavior) and new functionality with reproducible steps.

**Test plan**

- Built docs locally with Sphinx: `cd docs && make html`
- Opened and reviewed generated pages in browser:
  - `build/html/tutorials/home-assistant-write-tutorial.html`
  - `build/html/agent-framework/driver-framework/home-assistant/HomeAssistantDriver.html`
- Verified:
  - Mermaid architecture diagram renders.
  - Cross-reference between tutorial and driver doc resolves.
  - Updated headings/content render correctly and match intended workflow tone.